### PR TITLE
feat: Add timeout to GitHub repository cloning

### DIFF
--- a/src/fetcher/code_fetcher.py
+++ b/src/fetcher/code_fetcher.py
@@ -101,7 +101,7 @@ class GithubFetcher(BaseFetcher):
 
         # Clone the repository
         try:
-            git.Repo.clone_from(url_info.git_url, output_path)
+            git.Repo.clone_from(url_info.git_url, output_path,kill_after_timeout=30) 
 
             # Checkout specific branch or commit if specified
             if url_info.branch:

--- a/src/fetcher/code_fetcher.py
+++ b/src/fetcher/code_fetcher.py
@@ -101,7 +101,7 @@ class GithubFetcher(BaseFetcher):
 
         # Clone the repository
         try:
-            git.Repo.clone_from(url_info.git_url, output_path,kill_after_timeout=30) 
+            git.Repo.clone_from(url_info.git_url, output_path,kill_after_timeout=60) 
 
             # Checkout specific branch or commit if specified
             if url_info.branch:


### PR DESCRIPTION
Hello, I had some issue with some Audit report that contains the github repo url. However, the url was no longer available (error 404). Hence the cloning process takes forever hence I added a new parameter.